### PR TITLE
Undefined name: util.warn in ibm_db.py

### DIFF
--- a/ibm_db_alembic/ibm_db_alembic/ibm_db.py
+++ b/ibm_db_alembic/ibm_db_alembic/ibm_db.py
@@ -21,6 +21,7 @@
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import reflection
+from sqlalchemy.util import warn
 from sqlalchemy import schema as sa_schema
 from sqlalchemy import types as sa_types
 from ibm_db_sa import reflection as ibm_db_reflection
@@ -85,7 +86,7 @@ class IbmDbImpl(DefaultImpl):
             insp = reflection.Inspector.from_engine(self.connection)
             primary_key_columns = insp.get_pk_constraint(table_name, schema).get('constrained_columns')
         if autoincrement is not None or existing_autoincrement is not None:
-            util.warn("autoincrement and existing_autoincrement only make sense for MySQL")
+            warn("autoincrement and existing_autoincrement only make sense for MySQL")
         if nullable is not None:
             self._exec(base.ColumnNullable(table_name, column_name,
                                 nullable, schema=schema,


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/ibmdb/python-ibmdbalembic on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./ibm_db_alembic/ibm_db_alembic/ibm_db.py:88:13: F821 undefined name 'util'
            util.warn("autoincrement and existing_autoincrement only make sense for MySQL")
            ^
1     F821 undefined name 'util'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

* F821 tests are _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

DCO 1.1 Signed-off-by: Christian Clauss cclauss@me.com